### PR TITLE
README cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
+# Ignore user config
 phoenixd-lnurl.env
 
 # Ruff formatter
 .ruff-cache/
+
+# example docker-compose volumes
+examples/letsencrypt/
+examples/phoenixd-data/
 
 # From: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supports **one** user with a human-readable LNURL like `lightning:satoshi@gmx.co
 ![Tip page screenshots (web and phone)](./img/screenshot.jpg)
 
 The idea is that you can run your own `phoenixd` instance and use it to receive Lightning tips, Zaps on Nostr and more-generally small usually un-requested payments.
-This is intended for a single person to use, because they like self-hosting and owning their own stuff.
+This is intended for a single person to use, because you like self-hosting and owning your own stuff.
 
 If you're looking for something more complex, like an eCommerce Lightning solution, this is almost certainly going to be too simple for you;
 check out [LNBits](https://lnbits.com/) or [BTCPay Server](https://btcpayserver.org/) and other things like those.
@@ -30,9 +30,34 @@ Currently tested on MacOS and Linux; YMMV on other UNIXes, and on Windows.
  * [LUD-16](https://github.com/lnurl/luds/blob/luds/16.md): Paying to static internet identifiers *(email-like addresses)*.
 
 
-## Install
 
-*Note: Docker can be used to run this instead*
+## Docker Setup
+
+A docker container with the latest release is available from `ghcr.io/angusp/phoenixd-lnurl:latest`.
+
+Each of the settings in [`phoenixd-lnurl.env`](./phoenixd-lnurl.env.example) can be set using environment variables passed to the container, which is probably the easiest way to set this up.
+
+As you'll also need to run phoenixd and some sort of webserver, so using **Docker compose** is likely easiest way to get all of the required pieces running: [./examples/docker-compose.yml](./examples/docker-compose.yml)
+
+```shell
+# Pull the image:
+docker pull ghcr.io/angusp/phoenixd-lnurl:latest
+docker tag ghcr.io/angusp/phoenixd-lnurl:latest phoenixd-lnurl:latest
+# or build the image from a locally checked-out repo:
+docker build . -t phoenixd-lnurl:latest
+
+docker run -p 8000:8000 \
+    # Pass config as environment variables: (See phoenixd-lnurl.env.example for the list)
+    --env USERNAME=satoshi \
+    --env PHOENIXD_URL="http://_:hunter2@127.0.0.1:9740" \
+    --env LNURL_HOSTNAME=example.com \
+    # Or pass in a .env file:
+    --env-file phoenixd-lnurl.env \
+    -it phoenixd-lnurl:latest
+```
+
+
+## Non-Docker Setup
 
 If you haven't got it already, install [phoenixd](https://github.com/ACINQ/phoenixd/releases) so you have `phoenixd` and `phoenix-cli` in your path.
 
@@ -51,7 +76,6 @@ pip install pip-tools
 pip-sync
 ```
 
-## Setup
 
 Using this example `~/.phoenix/phoenix.conf` for demonstration purposes:
 
@@ -74,83 +98,23 @@ Importantly:
     * Note that the `http-password` from phoenixd's config has to be in this URL
  2. `LNURL_HOSTNAME` must be the public domain you're serving from. You need to have HTTPS set up for LNURL to work.
 
-*Finally*, you're ready to go!
+Now you're ready to run:
 
 ```shell
 # start the phoenixd-lnurl server:
 ./run.sh
 ```
 
-**Example Nginx config**
+To deploy, you probably want something to manage **phoenixd-lnurl** as a service, rather than running it directly.
+Some example config is provided to help with this:
 
-This Nginx config snippet will pass only the paths **phoenixd-lnurl** needs to work to the application:
+**Example configuration**:
 
-```
-server {
-    # ...
+* Docker compose: [./examples/docker-compose.yml](./examples/docker-compose.yml)
+* Nginx: [./examples/nginx.conf](./examples/nginx.conf)
+* Systemd: [./examples/pheonixd-lnurl.service](./examples/pheonixd-lnurl.service)
 
-    location /lnurl {
-        proxy_pass http://localhost:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-    }
-    location /lnurlp {
-        proxy_pass http://localhost:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-    }
-    location /.well-known/lnurlp {
-        proxy_pass http://localhost:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-    }
-
-    # ...
-}
-```
-
-(May also hit selinux, try `setsebool -P httpd_can_network_connect true`)
-
-
-**Example SystemD Unit**
-
-*Note* this assumes you have installed to `/var/www/phoenixd-lnurl`.
-You will also need to change `User` and `Group`.
-
-```conf
-[Unit]
-Description=phoenixd-lnurlp
-After=network.target
-
-[Service]
-User=<username>
-Group=<group>
-WorkingDirectory=/var/www/phoenixd-lnurl/src
-Environment="PATH=/var/www/phoenixd-lnurl/env/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
-ExecStart=/var/www/phoenixd-lnurl/run.sh
-
-[Install]
-WantedBy=multi-user.target
-```
-
-
-## Docker
-
-(*Follow the **Setup** steps to configure phoenixd-lnurl first*)
-
-```shell
-docker build . -t phoenixd-lnurl
-
-# ⚠️ This container will need to be able to connect to your `phoenixd` instance.
-# To do this you might need to fiddle with the config and/or docker networking.
-docker run -p 8000:8000 -it phoenixd-lnurl
-```
+(**Note**: You may also hit a selinux issue if using nginx, try `setsebool -P httpd_can_network_connect true`)
 
 
 ---
@@ -196,20 +160,22 @@ just serve
 - [X] Just receive LNURL LUD-16 payments (zaps)
 - [X] Simple "zap me" QR code and copyable `lightning:LNURL1...` link webpage LUD-16
 - [X] Provide sample Docker image
+- [X] Provide sample docker-compose config (credit @sethforprivacy)
 - [X] Provide sample Nginx config
 - [X] Provide sample Systemd service definition
 - [ ] Basic CI (check normal install, dev install)
-- [ ] Maybe also provide sample Traefik config
-- [ ] Support configurable URL prefix for the app for people that might have collisions (or do this in nginx conf)
+- [X] Provide sample Traefik config (in the docker-compose example) (credit @sethforprivacy)
 - [ ] Support `.onion` hosting (HTTPS is assumed in a few places), needed for self-hosting on things like Umbrel
 - [ ] Support [LUD-18: Payer identity in `payRequest` protocol](https://github.com/lnurl/luds/blob/luds/18.md)
+- [ ] Support configurable URL prefix for the app for people that might have collisions or don't want to host at `/` (or do this in nginx conf)
+- [ ] Support actual Nostr Zaps [NIP-57: Lightning Zaps](https://github.com/nostr-protocol/nips/blob/master/57.md)
+- [ ] Support [NIP-47: Nostr Wallet Connect](https://github.com/nostr-protocol/nips/blob/master/47.md)
 
 
 ### Later Roadmap
 
 - [ ] Notify when payments are received (Nostr DM?)
 - [ ] Support some kind of withdrawal mechanism (via Nostr DM?) instead of needing manual `phoenix-cli` use to get money out
-- [ ] Support actual Nostr Zaps
 - [ ] Also optionally be a Nostr NIP-05 server
 - [ ] Support multiple usernames
 - [ ] (maybe-scope-creep) auto-zap content you interact with/like on Nostr if funds are available
@@ -219,7 +185,7 @@ just serve
 
 ## Tips 😘
 
-`1f52b@1f52b.xyz` (yes, I am dogfooding) or [tip page](https://1f52b.xyz/lnurl)
+[`lnurlp:1f52b@1f52b.xyz`](lnurlp:1f52b@1f52b.xyz) (yes, I am dogfooding) or [tip page](https://1f52b.xyz/lnurl)
 
 
 ---

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   traefik:
+    platform: linux/amd64
+    # ALT: platform: linux/arm64
     image: "traefik:latest"
     container_name: "traefik"
     restart: unless-stopped
@@ -10,10 +12,12 @@ services:
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      # CHANGEME change `example.com` and email here to match your domain:
       - "--certificatesresolvers.selfhostedservices.acme.tlschallenge=true"
       - "--certificatesresolvers.selfhostedservices.acme.email=example@example.com"
       - "--certificatesresolvers.selfhostedservices.acme.storage=/letsencrypt/acme.json"
     ports:
+      # NOTE for local development, changing `published:` to 8000 and 4430 is easier
       - target: 80
         published: 80
         mode: host
@@ -25,9 +29,17 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   phoenixd-lnurl:
+    platform: linux/amd64
+    # ALT: platform: linux/arm64
     container_name: phoenixd-lnurl
     image: ghcr.io/angusp/phoenixd-lnurl:latest
+    environment:
+      # CHANGEME See phoenixd-lnurl.env.example for the full list
+      - USERNAME=satoshi
+      - PHOENIXD_URL=http://_:<phoenixd http password from phoenixd-data volume>@172.17.0.1:9740
+      - LNURL_HOSTNAME=example.com
     labels:
+      # CHANGEME set `Host(...)` to match your domain, or to `localhost` for testing:
       - "traefik.enable=true"
       - "traefik.http.routers.phoenixd-lnurl.rule=Host(`example.com`) && Path(`/lnurl`) || Host(`example.com`) && PathPrefix(`/lnurlp`) || Host(`example.com`) && PathPrefix(`/.well-known/lnurlp`)"
       - "traefik.http.services.phoenixd-lnurl.loadbalancer.server.port=8000"
@@ -35,6 +47,7 @@ services:
       - "traefik.http.routers.phoenixd-lnurl.tls.certresolver=selfhostedservices"
 
   phoenixd:
+    platform: linux/amd64
     image: ghcr.io/sethforprivacy/phoenixd:latest
     container_name: phoenixd
     volumes:

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    # Include this snipped in your nginx config
+    # ...
+
+    # phoenixd-lnurl
+    # proxy_pass only the paths needed to the app:
+    location /lnurl {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+    location /lnurlp {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+    location /.well-known/lnurlp {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+
+    # ...
+}

--- a/examples/phenixd-lnurl.service
+++ b/examples/phenixd-lnurl.service
@@ -1,0 +1,16 @@
+# NOTE you will need to change User= and Group=
+# This assumes you have installed to `/var/www/phoenixd-lnurl`.
+
+[Unit]
+Description=phoenixd-lnurlp
+After=network.target
+
+[Service]
+User=<username>
+Group=<group>
+WorkingDirectory=/var/www/phoenixd-lnurl/src
+Environment="PATH=/var/www/phoenixd-lnurl/env/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin"
+ExecStart=/var/www/phoenixd-lnurl/run.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/phoenixd-lnurl.env.example
+++ b/phoenixd-lnurl.env.example
@@ -5,12 +5,12 @@ USERNAME=satoshi
 ## The hostname (not including `https://` etc.) where you'll be running
 ## your LNURL. This is used to make your address e.g. `satoshi@example.com`,
 ## and also to provide the correct URLs in responses to payment requests.
-LNURL_HOSTNAME='example.com'
+LNURL_HOSTNAME=example.com
 
 ## URL of your `phoenixd` instance. Note the username (`satoshi` here)
 ## is not used, but you have to set it to something. `satoshi` or `_` work well.
 ## Your `phoenixd` instance will put its password in `~/.phoenix/phoenix.conf`
-PHOENIXD_URL='http://satoshi:hunter2@127.0.0.1:9740'
+PHOENIXD_URL=http://_:hunter2@127.0.0.1:9740
 
 ## Optional: set the minimum number of sats you wish to recieve in a single payment (default: 1)
 # MIN_SATS_RECEIVABLE=1
@@ -18,13 +18,13 @@ PHOENIXD_URL='http://satoshi:hunter2@127.0.0.1:9740'
 # MAX_SATS_RECEIVABLE=2100000000000000
 
 ## Optional; set to show a profile photo on your tips page `/lnurl`
-# USER_PROFILE_IMAGE_URL='https://example.com/your_profile_photo.png'
+# USER_PROFILE_IMAGE_URL=https://example.com/your_profile_photo.png
 
 ## Optional; set to show an `npub` or `nprofile` or NIP5 identifier on your tips page `/lnurl`
-# USER_NOSTR_ADDRESS='npub1...'
+# USER_NOSTR_ADDRESS=npub1...
 
 ## Optional & Technical: Change the log level. Values: "INFO" (default), "DEBUG", "WARNING", etc.
-# LOG_LEVEL='DEBUG'
+# LOG_LEVEL=DEBUG
 
 ## WARNING: Intended for development only, enables useful but dangerous-in-public debug features
 # DEBUG=1


### PR DESCRIPTION
* Put Docker setup at the top and link to docker-compose
* Move example configs to `examples/`
* Improve example docker-compose with notes about what needs to be changed to work

Fixes #3
