### PR TITLE
Move static (non-request-dependent) properties into PhoenixdLNURLSettings

### DIFF
--- a/app/main_test.py
+++ b/app/main_test.py
@@ -39,8 +39,9 @@ def test_lnurl_pay_request_lud06_happy():
     assert LnurlPayResponse.parse_obj(response.json()) == LnurlPayResponse.parse_obj(
         dict(
             callback="https://127.0.0.1/lnurlp/satoshi/callback",
-            minSendable=1000,
-            maxSendable=500_000,
+            # NOTE these are millisat values
+            minSendable=1_000_000,
+            maxSendable=500_000_000,
             metadata=json.dumps(
                 [
                     ["text/plain", "Zap satoshi some sats"],
@@ -81,8 +82,9 @@ def test_lnurl_pay_request_lud16_happy():
     assert LnurlPayResponse.parse_obj(response.json()) == LnurlPayResponse.parse_obj(
         dict(
             callback="https://127.0.0.1/lnurlp/satoshi/callback",
-            minSendable=1000,
-            maxSendable=500_000,
+            # NOTE these are millisat values
+            minSendable=1_000_000,
+            maxSendable=500_000_000,
             metadata=json.dumps(
                 [
                     ["text/plain", "Zap satoshi some sats"],

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,9 +1,15 @@
+import hashlib
+import json
+
+import lnurl
+import qrcode.image.svg
 from pydantic import (
     BaseSettings,
     Field,
     HttpUrl,
     SecretStr,
 )
+from qrcode.main import QRCode
 from yarl import URL
 
 MAX_CORN = 21_000_000 * 100_000_000
@@ -25,15 +31,45 @@ class PhoenixdLNURLSettings(BaseSettings):
     # Set in test environments. Unsafe on prod.
     is_test: bool = False
 
+    # TODO use @computed_field when upgrading to Pydantic 2.x
+    # https://docs.pydantic.dev/2.6/api/fields/#pydantic.fields.computed_field
+    # So we can also use @functools.cached_property
+
     def base_url(self) -> URL:
         # TODO support `http` for `.onion` only (per LNURL spec)
         return URL(f"https://{self.lnurl_hostname}")
 
+    def is_long_username(self) -> bool:
+        return len(self.username) > 10
+
     def lnurl_address(self) -> str:
         return f"{self.username}@{self.lnurl_hostname}"
 
-    def is_long_username(self) -> bool:
-        return len(self.username) > 10
+    def lnurl_address_encoded(self) -> lnurl.Lnurl:
+        return lnurl.encode(str(self.base_url() / "lnurlp" / self.username))
+
+    def lnurl_qr(self) -> str:
+        lnurl_qr = QRCode(
+            image_factory=qrcode.image.svg.SvgPathFillImage,
+            box_size=15,
+        )
+        lnurl_qr.add_data(self.lnurl_address_encoded())
+        lnurl_qr.make(fit=True)
+        return lnurl_qr.make_image().to_string(encoding="unicode")
+
+    def metadata_for_payrequest(self) -> str:
+        return json.dumps(
+            [
+                ["text/plain", f"Zap {self.username} some sats"],
+                ["text/identifier", self.lnurl_address()],
+                # ["image/jpeg;base64", "TODO optional"],
+            ]
+        )
+
+    def metadata_hash(self) -> str:
+        return hashlib.sha256(
+            self.metadata_for_payrequest().encode("UTF-8")
+        ).hexdigest()
 
     class Config:
         env_file = "phoenixd-lnurl.env"

--- a/app/settings_test.py
+++ b/app/settings_test.py
@@ -27,8 +27,8 @@ def test_default_settings_load():
     assert settings.is_test is True
     assert settings.debug is False
     assert settings.username == "satoshi"
-    assert settings.lnurl_hostname == "bitcoincore.org"
-    assert settings.phoenixd_url == SecretStr("http://satoshi:hunter2@127.0.0.1:9740")
+    assert settings.lnurl_hostname == "example.com"
+    assert settings.phoenixd_url == SecretStr("http://_:hunter2@127.0.0.1:9740")
     assert settings.user_nostr_address is None
     assert settings.user_profile_image_url is None
     assert settings.log_level == "INFO"
@@ -40,6 +40,20 @@ def test_testenv_settings_derived_properties():
     settings = PhoenixdLNURLSettings(_env_file="test.env")
     assert settings.base_url() == URL("https://127.0.0.1")
     assert settings.lnurl_address() == "satoshi@127.0.0.1"
+    assert (
+        settings.lnurl_address_encoded()
+        == "LNURL1DP68GURN8GHJ7VFJXUHRQT3S9CCJ7MRWW4EXCUP0WDSHGMMNDP5S4SDZXR"
+    )
+    assert settings.lnurl_qr()[:20] == '<svg width="61.5mm" '
+    assert (
+        settings.metadata_for_payrequest()
+        == '[["text/plain", "Zap satoshi some sats"], ["text/identifier", "satoshi@127.0.0.1"]]'
+    )
+    assert (
+        settings.metadata_hash()
+        == "297f16bedbf6942cdc656e19feb46a577a43a87e1f858fd8511ac7144b84f0de"
+    )
+
     assert settings.is_long_username() is False
 
     settings.username = "marttimalmi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,13 @@ select = [
     # isort
     "I",
 ]
-ignore = ["E501"]
+ignore = [
+    # line-too-long
+    # We're using `ruff` to format the code, so iff the formatter
+    # can't get the line length low enough we'll assume it reads better
+    # as a long line rather than broken up
+    "E501",
+]
 fixable = ["ALL"]
 
 [tool.ruff.lint.flake8-quotes]


### PR DESCRIPTION
This is part cleanup, part setup for using `@functools.cached_property` later (when we can use Pydantic 2.x) so we don't recompute things that don't change every time we get a request.