### PR TITLE
Add proper Nostr Zap Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,17 @@ FROM python:3.12-alpine
 
 WORKDIR /var/phoenixd_lnurl
 
+RUN \
+    apk update && \
+    apk add \
+        # secp256k1 requirements
+        automake \
+        build-base \
+        libffi-dev \
+        libtool \
+        pkgconfig \
+    ;
+
 COPY ./requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **🚧 NOTE This is new software, loss of funds and other mishaps are likely 🚧**
 
-A simple wrapper for [ACINQ/phoenixd](https://github.com/ACINQ/phoenixd) that supports basic [LNURL](https://github.com/lnurl/luds) so you can self-host your lightning address with near-minimum effort 💯.
+A simple wrapper for [ACINQ/phoenixd](https://github.com/ACINQ/phoenixd) that supports basic [LNURL](https://github.com/lnurl/luds) and Nostr Zaps so you can self-host your lightning address with near-minimum effort 💯.
 
 Supports **one** user with a human-readable LNURL like `lightning:satoshi@gmx.com`, as well as LNURL LUD-06 (the long Bech encoded `lightning:LNURL1blahblah` kind) *and* a snazzy [tip webpage at `/lnurl`](https://1f52b.xyz/lnurl):
 
@@ -47,6 +47,7 @@ Each of the settings in [`phoenixd-lnurl.env`](./phoenixd-lnurl.env.example) can
 As you'll also need to run phoenixd and some sort of webserver, so using **Docker compose** is likely easiest way to get all of the required pieces running: [./examples/docker-compose.yml](./examples/docker-compose.yml):
 
 ```shell
+# NOTE you'll need to change the config in docker-compose.yml for this to work properly!
 docker-compose -f examples/docker-compose.yml up
 ```
 
@@ -69,10 +70,12 @@ docker run -p 8000:8000 \
     -it phoenixd-lnurl:latest
 ```
 
+### URLs:
+
  * `localhost:8000/lnurl` Tip webpage as in the screenshot above
  * `localhost:8000/.well-known/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-16) for `<USERNAME>@<LNURL_HOSTNAME>`
  * `localhost:8000/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-06)
- * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16)
+ * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16, NIP-57)
  * `localhost:8000/.well-known/nostr.json` (Optional) Nostr NIP-5 server for `<USERNAME>@<LNURL_HOSTNAME>`
  * **⚠️ INTERNAL ONLY** `localhost:8000/phoenixd-webhook` -- you need to add this to your `~/.phoenixd/phoenix.conf` for Nostr Zaps to work correctly. ‼️ DO NOT make this publicly accessible ‼️
  * **Note** `localhost:8000/` and any other path will give you an `ERROR` -- that's supposed to happen, as it isn't a LNURL that **pheonixd-lnurl** understands 😉
@@ -126,10 +129,12 @@ Now you're ready to run:
 ./run.sh
 ```
 
+### URLs:
+
  * `localhost:8000/lnurl` Tip webpage as in the screenshot above
  * `localhost:8000/.well-known/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-16) for `<USERNAME>@<LNURL_HOSTNAME>`
  * `localhost:8000/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-06)
- * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16)
+ * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16, NIP-57)
  * `localhost:8000/.well-known/nostr.json` (Optional) Nostr NIP-5 server for `<USERNAME>@<LNURL_HOSTNAME>`
  * **⚠️ INTERNAL ONLY** `localhost:8000/phoenixd-webhook` -- you need to add this to your `~/.phoenixd/phoenix.conf` for Nostr Zaps to work correctly. ‼️ DO NOT make this publicly accessible ‼️
  * **Note** `localhost:8000/` and any other path will give you an `ERROR` -- that's supposed to happen, as it isn't a LNURL that **pheonixd-lnurl** understands 😉
@@ -197,9 +202,9 @@ just serve
 - [ ] Support `.onion` hosting (HTTPS is assumed in a few places), needed for self-hosting on things like Umbrel
 - [ ] Support [LUD-18: Payer identity in `payRequest` protocol](https://github.com/lnurl/luds/blob/luds/18.md)
 - [ ] Support configurable URL prefix for the app for people that might have collisions or don't want to host at `/` (or do this in nginx conf)
-- [ ] Support actual Nostr Zaps [NIP-57: Lightning Zaps](https://github.com/nostr-protocol/nips/blob/master/57.md)
+- [X] Support actual Nostr Zaps [NIP-57: Lightning Zaps](https://github.com/nostr-protocol/nips/blob/master/57.md)
 - [ ] Support [NIP-47: Nostr Wallet Connect](https://github.com/nostr-protocol/nips/blob/master/47.md)
-
+- [ ] Add optional auth on Phoenixd webhook endpoint
 
 ### Later Roadmap
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Currently tested on MacOS and Linux; YMMV on other UNIXes, and on Windows.
  * [LUD-06](https://github.com/lnurl/luds/blob/luds/06.md): `payRequest` base spec.
  * [LUD-16](https://github.com/lnurl/luds/blob/luds/16.md): Paying to static internet identifiers *(email-like addresses)*.
 
+### Supported Nostr NIPs:
+
+ * [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) Basic protocol flow description
+ * [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md): Mapping Nostr keys to DNS-based internet identifiers (as a NIP-5 server, optional)
+ * [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md): Lightning Zaps (receive only)
 
 
 ## Docker Setup
@@ -68,6 +73,8 @@ docker run -p 8000:8000 \
  * `localhost:8000/.well-known/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-16) for `<USERNAME>@<LNURL_HOSTNAME>`
  * `localhost:8000/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-06)
  * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16)
+ * `localhost:8000/.well-known/nostr.json` (Optional) Nostr NIP-5 server for `<USERNAME>@<LNURL_HOSTNAME>`
+ * **⚠️ INTERNAL ONLY** `localhost:8000/phoenixd-webhook` -- you need to add this to your `~/.phoenixd/phoenix.conf` for Nostr Zaps to work correctly. ‼️ DO NOT make this publicly accessible ‼️
  * **Note** `localhost:8000/` and any other path will give you an `ERROR` -- that's supposed to happen, as it isn't a LNURL that **pheonixd-lnurl** understands 😉
 
 
@@ -98,6 +105,7 @@ chain=testnet
 http-password=hunter2
 http-bind-port=9740
 auto-liquidity=2m
+webhook=http://localhost:8000/phoenixd-webhook
 ```
 
 For **production** use, you can *just* install and run `phoenixd` for the first time;
@@ -122,6 +130,8 @@ Now you're ready to run:
  * `localhost:8000/.well-known/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-16) for `<USERNAME>@<LNURL_HOSTNAME>`
  * `localhost:8000/lnurlp/<USERNAME>` LNURL payRequest endpoint (LUD-06)
  * `localhost:8000/lnurlp/<USERNAME>/callback?amount=<AMOUNT_MSAT>` LNURL payRequest callback (LUD-06 and LUD-16)
+ * `localhost:8000/.well-known/nostr.json` (Optional) Nostr NIP-5 server for `<USERNAME>@<LNURL_HOSTNAME>`
+ * **⚠️ INTERNAL ONLY** `localhost:8000/phoenixd-webhook` -- you need to add this to your `~/.phoenixd/phoenix.conf` for Nostr Zaps to work correctly. ‼️ DO NOT make this publicly accessible ‼️
  * **Note** `localhost:8000/` and any other path will give you an `ERROR` -- that's supposed to happen, as it isn't a LNURL that **pheonixd-lnurl** understands 😉
 
 To deploy, you probably want something to manage **phoenixd-lnurl** as a service, rather than running it directly.
@@ -198,13 +208,6 @@ just serve
 - [ ] Also optionally be a Nostr NIP-05 server
 - [ ] Support multiple usernames
 - [ ] (maybe-scope-creep) auto-zap content you interact with/like on Nostr if funds are available
-
-
----
-
-## Tips 😘
-
-[`lnurlp:1f52b@1f52b.xyz`](lnurlp:1f52b@1f52b.xyz) (yes, I am dogfooding) or [tip page](https://1f52b.xyz/lnurl)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LNURL for phoenixd ⚡️
 
-👾 Also available on the P2P Git forge, [Radicle](https://radicle.xyz) at `rad:z4G6sJdYgCqKswKnrBbYgn9QaHBqh`
+👾 Also available on the P2P Git forge, [Radicle](https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z4G6sJdYgCqKswKnrBbYgn9QaHBqh) at `rad:z4G6sJdYgCqKswKnrBbYgn9QaHBqh`
 
 **🚧 NOTE This is new software, loss of funds and other mishaps are likely 🚧**
 
@@ -20,7 +20,9 @@ Note that LNBits will support phoenixd [soon™️](https://github.com/lnbits/ln
 
 ## Compatibility
 
-Developed against `phoenixd version 0.1.4-04bd430` (and `0.1.3-d805f81`); also note that phoenixd is also new software and future releases may break things.
+Developed against [`phoenixd version 0.1.5-6845a31`](https://github.com/ACINQ/phoenixd/releases/tag/v0.1.5); also note that phoenixd is also new software and future releases may break things.
+
+Versions of Phoenixd before `0.1.5` can be used for LNURL, but Nostr zaps won't work as description-hash invoices [added in 0.1.5](https://github.com/ACINQ/phoenixd/pull/50) are needed.
 
 Currently tested on MacOS and Linux; YMMV on other UNIXes, and on Windows.
 

--- a/app/main_test.py
+++ b/app/main_test.py
@@ -7,6 +7,11 @@ from lnurl import (
 )
 
 from .main import app_factory
+from .models import (
+    NostrNIP5Response,
+    NostrZapReceipt,
+    NostrZapRequest,
+)
 
 app = app_factory()
 test_client = TestClient(app)
@@ -14,8 +19,8 @@ test_client = TestClient(app)
 
 def test_read_main():
     response = test_client.get("/")
-    assert response.status_code == 400
-    assert response.json() == {"status": "ERROR", "reason": "HTTPException "}
+    assert response.status_code == 404
+    assert response.json() == {"status": "ERROR", "reason": "Error"}
 
 
 def test_lnurl_get_lud01():
@@ -29,9 +34,26 @@ def test_lnurl_get_lud01():
         in response.text
     )
     assert (
-        "nostr:npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f"
+        "nostr:npub1az6txrn8e84tcuvsrpp4u4awgh7samp0dtdy9zcy690xw9ycsm8suq2sze"
         in response.text
     )
+
+
+def test_nostr_NIP5():
+    response = test_client.get("/.well-known/nostr.json")
+    assert NostrNIP5Response.parse_obj(response.json()) == NostrNIP5Response.parse_obj(
+        dict(
+            names=dict(
+                satoshi="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"
+            ),
+            relays={
+                "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf": [
+                    "wss://nostr.bitcoin.org",
+                ]
+            },
+        )
+    )
+    assert response.status_code == 200
 
 
 def test_lnurl_pay_request_lud06_happy():
@@ -68,7 +90,7 @@ def test_lnurl_pay_request_lud06_bad_user():
     assert response.json() == {
         "status": "ERROR",
         "reason": (
-            "RequestValidationError 1 validation error for Request\n"
+            "1 validation error for Request\n"
             "path -> username\n"
             '  string does not match regex "^[a-z0-9-_\\.]+$" '
             "(type=value_error.str.regex; pattern=^[a-z0-9-_\\.]+$)"
@@ -111,7 +133,7 @@ def test_lnurl_pay_request_lud16_bad_user():
     assert response.json() == {
         "status": "ERROR",
         "reason": (
-            "RequestValidationError 1 validation error for Request\n"
+            "1 validation error for Request\n"
             "path -> username\n"
             '  string does not match regex "^[a-z0-9-_\\.]+$" '
             "(type=value_error.str.regex; pattern=^[a-z0-9-_\\.]+$)"
@@ -127,7 +149,10 @@ def test_lnurl_pay_request_callback_lud06_happy():
         response = local_client.get(
             "/lnurlp/satoshi/callback",
             # NOTE the amount here is millisatoshis
-            params=[("amount", 1337 * 1000)],
+            params=[
+                ("amount", 1337 * 1000),
+                ("comment", "Onwards! 🫡"),
+            ],
         )
     assert LnurlPayActionResponse.parse_obj(
         response.json()
@@ -201,10 +226,235 @@ def test_lnurl_pay_request_callback_lud06_bad_amount():
     assert response.json() == {
         "status": "ERROR",
         "reason": (
-            "RequestValidationError 1 validation error for Request\n"
+            "1 validation error for Request\n"
             "query -> amount\n"
             "  ensure this value is greater than 0 "
             "(type=value_error.number.not_gt; limit_value=0)"
         ),
     }
     assert response.status_code == 400
+
+
+def test_lnurl_pay_request_callback_lud06_nostr_happy():
+    # NOTE the amount here is millisatoshis
+    amount = 1337 * 1000
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        sig="6e620802ec934fdc7580df54a852161e9732414d0963c10de9f42b831065cf139b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with TestClient(app) as local_client:
+        response = local_client.get(
+            "/lnurlp/satoshi/callback",
+            params=[
+                ("amount", amount),
+                ("nostr", zap_request.json(by_alias=True, exclude_unset=False)),
+            ],
+        )
+    assert LnurlPayActionResponse.parse_obj(
+        response.json()
+    ) == LnurlPayActionResponse.parse_obj(
+        dict(
+            pr=(
+                "lntb1u1pnquurmpp5xr83mlrg4d79e5w8nsrq6fksq83kreptr8uvcyy3"
+                "0r2fsve9n6fqcqpjsp5ut3l5lvwpwyjcqf508nzdtze65zl2yycm45uee"
+                "elktu3phzv2fsq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdrytddjyar"
+                "90p69ctmsd3skjm3z9s395ctsypekzar0wd5xjgja93djyar90p69ctmf"
+                "v3jkuarfve5k2u3z9s38xct5daeks6fzt4wsmqz9grzjqwfn3p9278ttz"
+                "zpe0e00uhyxhned3j5d9acqak5emwfpflp8z2cnflcdkeu6euv7gsqqqq"
+                "lgqqqqqeqqjqvyrulmkm8x58s9vahdm3z7jlj00pgl04xhfd0gjlm0e5e"
+                "z7llfg49ra6pl96808deh95ysvmxajhfse4033k2deh58mrgdjj8kz8s6"
+                "gpd82r8j"
+            ),
+            routes=[],
+            success_action={
+                "tag": "message",
+                "message": "Thanks for zapping satoshi",
+            },
+        )
+    )
+    assert response.status_code == 200
+
+
+def test_lnurl_pay_request_callback_lud06_nostr_unparsable_zap_request():
+    # NOTE the amount here is millisatoshis
+    amount = 1337 * 1000
+    with TestClient(app) as local_client:
+        response = local_client.get(
+            "/lnurlp/satoshi/callback",
+            params=[
+                ("amount", amount),
+                # Un-parsable zap_request should be ignored
+                ("nostr", {"kind": 9734, "id": "None"}),
+            ],
+        )
+    assert LnurlPayActionResponse.parse_obj(
+        response.json()
+    ) == LnurlPayActionResponse.parse_obj(
+        dict(
+            pr=(
+                "lntb1u1pnquurmpp5xr83mlrg4d79e5w8nsrq6fksq83kreptr8uvcyy3"
+                "0r2fsve9n6fqcqpjsp5ut3l5lvwpwyjcqf508nzdtze65zl2yycm45uee"
+                "elktu3phzv2fsq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdrytddjyar"
+                "90p69ctmsd3skjm3z9s395ctsypekzar0wd5xjgja93djyar90p69ctmf"
+                "v3jkuarfve5k2u3z9s38xct5daeks6fzt4wsmqz9grzjqwfn3p9278ttz"
+                "zpe0e00uhyxhned3j5d9acqak5emwfpflp8z2cnflcdkeu6euv7gsqqqq"
+                "lgqqqqqeqqjqvyrulmkm8x58s9vahdm3z7jlj00pgl04xhfd0gjlm0e5e"
+                "z7llfg49ra6pl96808deh95ysvmxajhfse4033k2deh58mrgdjj8kz8s6"
+                "gpd82r8j"
+            ),
+            routes=[],
+            success_action={
+                "tag": "message",
+                "message": "Thanks for zapping satoshi",
+            },
+        )
+    )
+    assert response.status_code == 200
+
+
+def test_lnurl_pay_request_callback_lud06_nostr_invalid_zap_request():
+    # NOTE the amount here is millisatoshis
+    amount = 1337 * 1000
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        # Signature is missing so request will obviously fail Nostr validation
+        sig="",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with TestClient(app) as local_client:
+        response = local_client.get(
+            "/lnurlp/satoshi/callback",
+            params=[
+                ("amount", amount),
+                ("nostr", zap_request.json(by_alias=True, exclude_unset=False)),
+            ],
+        )
+    # If we got something that looked like a Zap Request but couldn't handle it
+    # we return an error rather than continue with plain LNURL
+    assert response.json() == {
+        "status": "ERROR",
+        "reason": "Invalid NIP-57 Zap Request event: Invalid signature on event",
+    }
+    assert response.status_code == 400
+
+
+def test_phoenixd_webhook_happy():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        sig="6e620802ec934fdc7580df54a852161e9732414d0963c10de9f42b831065cf139b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/phoenixd-webhook",
+            json=dict(
+                type="payment_received",
+                amountSat=10,
+                paymentHash="30cf1dfc68ab7c5cd1c79c060d26d001e361e42b19f8cc109178d49833259e92",
+                externalId="zap-c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+            ),
+        )
+    assert response.json() == {
+        "status": "ok",
+        "receipt": NostrZapReceipt(
+            kind=9735,
+            id="d0c7e1dc8712c662c76dac9016bcf452cb31bd46c81fdc7feedebef5f760578d",
+            sig="6f4450f447de758fbdb95a81acbc194c5be90888ba1dd68f0fcea75656f8de887f63b46aca5f3a6be8a17411e4a6b163718de59fe56cf29fcf706a754bf9c110",
+            pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+            created_at=1713300291,
+            tags=[
+                [
+                    "p",
+                    "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+                ],
+                [
+                    "e",
+                    "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322",
+                ],
+                [
+                    "P",
+                    "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+                ],
+                [
+                    "bolt11",
+                    "lntb1u1pnquurmpp5xr83mlrg4d79e5w8nsrq6fksq83kreptr8uvcyy3"
+                    "0r2fsve9n6fqcqpjsp5ut3l5lvwpwyjcqf508nzdtze65zl2yycm45uee"
+                    "elktu3phzv2fsq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdrytddjyar"
+                    "90p69ctmsd3skjm3z9s395ctsypekzar0wd5xjgja93djyar90p69ctmf"
+                    "v3jkuarfve5k2u3z9s38xct5daeks6fzt4wsmqz9grzjqwfn3p9278ttz"
+                    "zpe0e00uhyxhned3j5d9acqak5emwfpflp8z2cnflcdkeu6euv7gsqqqq"
+                    "lgqqqqqeqqjqvyrulmkm8x58s9vahdm3z7jlj00pgl04xhfd0gjlm0e5e"
+                    "z7llfg49ra6pl96808deh95ysvmxajhfse4033k2deh58mrgdjj8kz8s6"
+                    "gpd82r8j",
+                ],
+                ["description", zap_request.invoice_description()],
+                [
+                    "preimage",
+                    "ee42430339e9d9c88b8b25f6d82eced562af242f0c24cbd728582992b804d168",
+                ],
+            ],
+            content="",
+        ).dict(
+            by_alias=True,
+            exclude_unset=False,
+        ),
+    }
+    assert response.status_code == 200
+
+
+def test_phoenixd_webhook_happy_not_a_zap():
+    with TestClient(app) as local_client:
+        response = local_client.post(
+            "/phoenixd-webhook",
+            json=dict(
+                type="payment_received",
+                amountSat=10,
+                paymentHash="30cf1dfc68ab7c5cd1c79c060d26d001e361e42b19f8cc109178d49833259e92",
+                externalId="lnurl-297f16bedbf6942cdc656e19feb46a577a43a87e1f858fd8511ac7144b84f0de",
+            ),
+        )
+    assert response.json() == {"status": "ok"}
+    assert response.status_code == 200

--- a/app/models.py
+++ b/app/models.py
@@ -190,6 +190,9 @@ class NostrZapRequest(BaseModel):
             separators=(",", ":"),
         )
 
+    def invoice_description_hash(self) -> str:
+        return sha256(self.invoice_description().encode("utf-8")).hexdigest()
+
 
 class NostrZapReceipt(BaseModel):
     kind: Literal[9735] = 9735

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,260 @@
+import json
+from hashlib import sha256
+from typing import (
+    Literal,
+    Union,
+)
+
+from lnurl.models import LnurlResponseModel
+from lnurl.types import (
+    ClearnetUrl,
+    DebugUrl,
+    LnurlPayMetadata,
+    MilliSatoshi,
+    OnionUrl,
+)
+from loguru import logger
+from pydantic import (
+    BaseModel,
+    Field,
+    validator,
+)
+
+# NOTE no type hints available for secp256k1
+from secp256k1 import (  # type: ignore
+    PrivateKey,
+    PublicKey,
+)
+
+from .phoenixd_client import IncomingPaymentResponse
+
+
+class LnurlPayNostrResponse(LnurlResponseModel):
+    tag: Literal["payRequest"] = "payRequest"
+    callback: Union[ClearnetUrl, OnionUrl, DebugUrl]
+    min_sendable: MilliSatoshi = Field(..., alias="minSendable")
+    max_sendable: MilliSatoshi = Field(..., alias="maxSendable")
+    metadata: LnurlPayMetadata
+
+    comment_allowed: int | None = Field(None, alias="commentAllowed", ge=1)
+    allows_nostr: Literal[True] | None = Field(None, alias="allowsNostr")
+    nostr_pubkey: str | None = Field(None, alias="nostrPubkey")
+
+    @validator("max_sendable")
+    def max_less_than_min(cls, value, values, **kwargs):  # noqa
+        if "min_sendable" in values and value < values["min_sendable"]:
+            raise ValueError("`max_sendable` cannot be less than `min_sendable`.")
+        return value
+
+    @validator("nostr_pubkey")
+    def check_pubkey(cls, value, values, **kwargs):  # noqa
+        if value and value.startswith("n"):
+            raise ValueError("nostrPubkey must be hex encoded")
+        bytes.fromhex(value)
+        return value
+
+
+class PhoenixdWebsocketNotification(BaseModel):
+    hook_type: Literal["payment_received"] = Field(alias="type")
+    amount_sat: int = Field(alias="amountSat")
+    payment_hash: str = Field(alias="paymentHash")
+    external_id: str | None = Field(None, alias="externalId")
+
+
+class NostrNIP5Response(BaseModel):
+    names: dict[str, str]
+    relays: dict[str, list[str]]
+
+
+def get_event_id_NIP1(
+    *,
+    pubkey: str,
+    created_at: int,
+    kind: int,
+    tags: list[list[str]],
+    content: str,
+) -> str:
+    nip1_format = [
+        0,
+        pubkey.lower(),
+        created_at,
+        kind,
+        tags,
+        content,
+    ]
+    serialized = json.dumps(
+        nip1_format,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return sha256(serialized.encode("UTF-8")).hexdigest()
+
+
+class NostrZapRequest(BaseModel):
+    kind: Literal[9734] = 9734
+    nostr_id: str = Field(alias="id")
+    sig: str
+    pubkey: str
+    created_at: int
+    tags: list[list[str]]
+    content: str
+
+    def _request_amount_msat(self) -> int | None:
+        for tag_key, *tag_values in self.tags:
+            if tag_key != "amount":
+                continue
+            if len(tag_values) != 1:
+                continue
+            return int(tag_values[0])
+        return None
+
+    def request_recipient_nostr_key(self) -> str | None:
+        p_tag = None
+        for tag_key, *tag_values in self.tags:
+            if tag_key != "p":
+                continue
+            if len(tag_values) != 1:
+                continue
+            if p_tag is not None:
+                raise ValueError("Multiple `p` tags in event")
+            p_tag = str(tag_values[0])
+        return p_tag
+
+    def zapped_event(self) -> str | None:
+        e_tag = None
+        for tag_key, *tag_values in self.tags:
+            if tag_key != "e":
+                continue
+            if len(tag_values) != 1:
+                continue
+            if e_tag is not None:
+                raise ValueError("Multiple `e` tags in event")
+            e_tag = str(tag_values[0])
+        return e_tag
+
+    def receipt_relays(self) -> list[str]:
+        relays = []
+        for tag_key, *tag_values in self.tags:
+            if tag_key != "relays":
+                continue
+            relays = [str(v) for v in tag_values]
+        return relays
+
+    def is_valid(
+        self,
+        amount_msat: int,
+        expected_nostr_pubkey: str | None,
+    ) -> bool:
+        self.verify_signature()
+        if nostr_amount := self._request_amount_msat():
+            if nostr_amount != amount_msat:
+                raise ValueError("Amount does not match")
+        if self.request_recipient_nostr_key() != expected_nostr_pubkey:
+            raise ValueError("Recipient pubkey doesn't match expected value")
+        if self.zapped_event() is None:
+            raise ValueError("No 'e' tag in Zap Request")
+        # TODO validate tags per https://github.com/nostr-protocol/nips/blob/master/57.md#appendix-d-lnurl-server-zap-request-validation
+        return True
+
+    def verify_signature(self) -> bool:
+        event_id = get_event_id_NIP1(
+            pubkey=self.pubkey.lower(),
+            created_at=self.created_at,
+            kind=self.kind,
+            tags=self.tags,
+            content=self.content,
+        )
+        if event_id != self.nostr_id:
+            raise ValueError(
+                f"Computed event ID did not match event's given ID ({event_id} != {self.nostr_id})"
+            )
+        # prefix with `02`` for Schnorr (BIP340)
+        public_key = PublicKey(pubkey=bytes.fromhex("02" + self.pubkey), raw=True)
+        if not public_key.schnorr_verify(
+            msg=bytes.fromhex(event_id),
+            schnorr_sig=bytes.fromhex(self.sig),
+            bip340tag=None,
+            raw=True,
+        ):
+            raise ValueError("Invalid signature on event")
+        return True
+
+    def invoice_description(self) -> str:
+        # Per NIP-57, invoices for Zaps should set the invoice's
+        # description to the provided zap request note
+        return self.json(
+            by_alias=True,
+            exclude_unset=False,
+            # Args to json.dumps:
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+
+
+class NostrZapReceipt(BaseModel):
+    kind: Literal[9735] = 9735
+    nostr_id: str = Field(alias="id")
+    sig: str
+    pubkey: str
+    created_at: int
+    tags: list[list[str]]
+    content: str = Field("", max_length=0)
+
+    @classmethod
+    def from_zap_request(
+        cls,
+        *,
+        zap_request: NostrZapRequest,
+        paid_invoice: IncomingPaymentResponse,
+        nostr_pubkey: str,
+        nostr_private_key: PrivateKey,
+    ) -> "NostrZapReceipt":
+        description_tag = zap_request.invoice_description()
+        if (
+            sha256(description_tag.encode("UTF-8")).hexdigest()
+            != sha256((paid_invoice.description or "").encode("UTF-8")).hexdigest()
+        ):
+            logger.warning("Invoice and Zap Request don't match")
+        if (recipient_nostr_key := zap_request.request_recipient_nostr_key()) is None:
+            raise ValueError("Couldn't parse recipient Nostr key out of Zap Request")
+        if (zapped_event := zap_request.zapped_event()) is None:
+            raise ValueError("Can't find the event ID for this Zap Request")
+        tags: list[list[str]] = [
+            # MUST include the p tag (zap recipient)
+            ["p", recipient_nostr_key],
+            # AND optional e tag from the zap request
+            ["e", zapped_event],
+            # AND optional P tag from the pubkey of the zap request (zap sender)
+            ["P", zap_request.pubkey],
+            # MUST have a bolt11 tag containing the description hash bolt11 invoice
+            ["bolt11", paid_invoice.invoice],
+            # MUST contain a description tag which is the JSON-encoded invoice description
+            ["description", description_tag],
+            # MAY contain a preimage tag to match against the payment hash of the bolt11 invoice
+            ["preimage", paid_invoice.preimage],
+        ]
+        # The content SHOULD be empty
+        content = ""
+        # The created_at date SHOULD be set to the invoice paid_at date
+        receipt_creation_timestamp = int(paid_invoice.completed_at.timestamp())
+
+        receipt_event_id = get_event_id_NIP1(
+            pubkey=nostr_pubkey,
+            created_at=receipt_creation_timestamp,
+            kind=9735,
+            tags=tags,
+            content=content,
+        )
+        sig = nostr_private_key.schnorr_sign(
+            msg=bytes.fromhex(receipt_event_id),
+            bip340tag=None,
+            raw=True,
+        )
+        return cls(
+            id=receipt_event_id,
+            sig=sig.hex(),
+            pubkey=nostr_pubkey,
+            created_at=receipt_creation_timestamp,
+            tags=tags,
+            content=content,
+        )

--- a/app/models.py
+++ b/app/models.py
@@ -37,7 +37,7 @@ class LnurlPayNostrResponse(LnurlResponseModel):
     metadata: LnurlPayMetadata
 
     comment_allowed: int | None = Field(None, alias="commentAllowed", ge=1)
-    allows_nostr: Literal[True] | None = Field(None, alias="allowsNostr")
+    allows_nostr: bool | None = Field(None, alias="allowsNostr")
     nostr_pubkey: str | None = Field(None, alias="nostrPubkey")
 
     @validator("max_sendable")

--- a/app/models_test.py
+++ b/app/models_test.py
@@ -1,0 +1,255 @@
+from datetime import datetime
+
+import pytest
+from secp256k1 import PrivateKey  # type: ignore
+
+from .models import (
+    NostrZapReceipt,
+    NostrZapRequest,
+)
+from .phoenixd_client import IncomingPaymentResponse
+
+
+def test_nostr_zap_request_happy():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        sig=(
+            "6e620802ec934fdc7580df54a852161e9732414d0963c10de9f42b831065cf13"
+            "9b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116"
+        ),
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    assert (
+        zap_request.is_valid(
+            amount_msat=1337000,
+            expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        )
+        is True
+    )
+    assert (
+        zap_request.request_recipient_nostr_key()
+        == "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"
+    )
+    assert (
+        zap_request.zapped_event()
+        == "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"
+    )
+    assert zap_request.receipt_relays() == [
+        "wss://relay.nostr.band/",
+        "wss://nos.lol/",
+        "wss://relay.damus.io/",
+    ]
+    assert zap_request.invoice_description() == (
+        '{"kind":9734,"id":"c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d'
+        '43bff8fa921914","sig":"6e620802ec934fdc7580df54a852161e9732414d0963c1'
+        "0de9f42b831065cf139b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4"
+        '788da3a1fe116","pubkey":"e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada'
+        '428b04d15e67149886cf","created_at":1713722971,"tags":[["p","e8b4b30e6'
+        '7c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],["amount","'
+        '1337000"],["relays","wss://relay.nostr.band/","wss://nos.lol/","wss:/'
+        '/relay.damus.io/"],["e","4af818a397daa226a85e8012197bee9ac4fd9cce85b4'
+        '949334481d0c5bc57322"]],"content":""}'
+    )
+
+
+def test_nostr_zap_receipt_happy():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        sig=(
+            "6e620802ec934fdc7580df54a852161e9732414d0963c10de9f42b831065cf13"
+            "9b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116"
+        ),
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    assert zap_request.is_valid(
+        amount_msat=1337000,
+        expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+    )
+    nostr_private_key = PrivateKey(
+        privkey=bytes.fromhex(
+            "661a629b00517e6c55f75eeead359510abe1f2c04e06531abafb3e666fcaafaf"
+        ),
+        raw=True,
+    )
+    paid_invoice = IncomingPaymentResponse(
+        paymentHash="paymentHash",
+        preimage="preimage",
+        invoice="lntb....",
+        isPaid=True,
+        receivedSat=1337,
+        fees=1,
+        completedAt=datetime.fromtimestamp(1713722981),
+        createdAt=datetime.fromtimestamp(1713722971),
+        description=zap_request.invoice_description(),
+        externalId="zap-2612f615-226d-48f2-a4d1-6b89f6747914",
+    )
+    zap_receipt = NostrZapReceipt.from_zap_request(
+        zap_request=zap_request,
+        paid_invoice=paid_invoice,
+        nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        nostr_private_key=nostr_private_key,
+    )
+    assert zap_receipt == NostrZapReceipt(
+        kind=9735,
+        id="6d3892986f47970746d89455086dec66f06eed32dcea211c4c2cefd7f2e75e10",
+        sig="998d68f150418fc4e55d670d3217c78d862dafc56e5551f6ee49c2b7899825e9c3f3cf93e2b3024013f4a1798bc868cb8a4edb07fbf2e48734f78a728bed9049",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722981,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+            ["P", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["bolt11", "lntb...."],
+            ["description", zap_request.invoice_description()],
+            ["preimage", "preimage"],
+        ],
+        content="",
+    )
+
+
+def test_nostr_zap_request_invalid_id():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        # Incorrect ID for the event
+        id="missing",
+        sig=(
+            "6e620802ec934fdc7580df54a852161e9732414d0963c10de9f42b831065cf13"
+            "9b8e9f8aa333b4281376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116"
+        ),
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with pytest.raises(ValueError) as exc_info:
+        zap_request.is_valid(
+            amount_msat=1337000,
+            expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        )
+    assert exc_info.value.args[0] == (
+        "Computed event ID did not match event's given ID "
+        "(c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914 != missing)"
+    )
+
+
+def test_nostr_zap_request_invalid_signature():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="c66329d84a2acf1c11296b3efc42931dd00d76b8bfb8e5b37d43bff8fa921914",
+        # Signature from a different event
+        sig="bb31687b6bfa319339008f7fcd862430109b9969771cdff4218828b13cbbf3cc82aa75a593019972d8b3d0f45777809a3fa5e81d7d26567e4db8ca2582038c22",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with pytest.raises(ValueError) as exc_info:
+        zap_request.is_valid(
+            amount_msat=1337000,
+            expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        )
+    assert exc_info.value.args[0] == "Invalid signature on event"
+
+
+def test_nostr_zap_request_invalid_recipient_pubkey():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="479f36282977c0d22b80d28b5d42c1c6a978d19b7d440707430e889758849d23",
+        sig="bf6c5268a0d56a7c9f563aadc953bef8383574c81e85671bd0f526e0637663335e63f9ac1368543351783e77a4fc4a55c01c9e43d5233facccf1547679fad921",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            # Not our pubkey
+            ["p", "84dee6e676e5bb67b4ad4e042cf70cbd8681155db535942fcc6a0533858a7240"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+            ["e", "4af818a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc57322"],
+        ],
+        content="",
+    )
+    with pytest.raises(ValueError) as exc_info:
+        zap_request.is_valid(
+            amount_msat=1337000,
+            expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        )
+    assert exc_info.value.args[0] == "Recipient pubkey doesn't match expected value"
+
+
+def test_nostr_zap_request_invalid_missing_e_tag():
+    zap_request = NostrZapRequest(
+        kind=9734,
+        id="082615a1887fdb49528e5ab141629c1b7c392d37ae904ae788bf0fed38cdbdc3",
+        sig="64648fea2fc883e042683c1f679fe4cb163bcc5f361179ec9966118345217333ad9e560247f27a7620eb3d9175c1f63999017916d2524e47a9c83b4fa72f29f9",
+        pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        created_at=1713722971,
+        tags=[
+            ["p", "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"],
+            ["amount", "1337000"],
+            [
+                "relays",
+                "wss://relay.nostr.band/",
+                "wss://nos.lol/",
+                "wss://relay.damus.io/",
+            ],
+        ],
+        content="",
+    )
+    with pytest.raises(ValueError) as exc_info:
+        zap_request.is_valid(
+            amount_msat=1337000,
+            expected_nostr_pubkey="e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf",
+        )
+    assert exc_info.value.args[0] == "No 'e' tag in Zap Request"

--- a/app/phoenixd_client.py
+++ b/app/phoenixd_client.py
@@ -2,6 +2,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from datetime import datetime
 
 import aiohttp
 from loguru import logger
@@ -43,6 +44,19 @@ class CreateInvoiceResponse(BaseModel):
     serialized: str
 
 
+class IncomingPaymentResponse(BaseModel):
+    payment_hash: str = Field(alias="paymentHash")
+    preimage: str
+    invoice: str
+    is_paid: bool = Field(alias="isPaid")
+    received_sat: int = Field(alias="receivedSat")
+    fees: int
+    completed_at: datetime = Field(alias="completedAt")
+    created_at: datetime = Field(alias="createdAt")
+    description: str | None
+    external_id: str | None = Field(alias="externalId")
+
+
 class PhoenixdClientBase(ABC):
     @abstractmethod
     async def getinfo(self) -> GetInfoResponse: ...
@@ -67,7 +81,7 @@ class PhoenixdClientBase(ABC):
         self,
         *,
         amount_sat: int,
-        description: str | bytes,
+        description: str,
         external_id: str | None = None,
     ) -> CreateInvoiceResponse: ...
 
@@ -89,10 +103,14 @@ class PhoenixdClientBase(ABC):
     ): ...
 
     @abstractmethod
-    async def incoming_payments_external_id(self, external_id: str): ...
+    async def incoming_payments_external_id(
+        self, external_id: str
+    ) -> list[IncomingPaymentResponse]: ...
 
     @abstractmethod
-    async def incoming_payment_hash(self, hash: str | bytes): ...
+    async def incoming_payment_hash(
+        self, payment_hash: str
+    ) -> IncomingPaymentResponse: ...
 
     @abstractmethod
     async def outgoing_payment_id(self, payment_id: str): ...
@@ -138,7 +156,7 @@ class PhoenixdHttpClient(PhoenixdClientBase):
         self,
         *,
         amount_sat: int,
-        description: str | bytes,
+        description: str,
         external_id: str | None = None,
     ) -> CreateInvoiceResponse:
         form_data = {
@@ -151,6 +169,10 @@ class PhoenixdHttpClient(PhoenixdClientBase):
             self.baseurl / "createinvoice",
             data=form_data,
         ) as response:
+            if response.status != 200:
+                raise ValueError(
+                    f"Error creating invoice, Phoenixd responded non-200: {await response.text()}"
+                )
             invoice = CreateInvoiceResponse.parse_obj(await response.json())
         logger.info(
             "Created invoice {inv_short}... externalId: '{external_id}'",
@@ -177,11 +199,23 @@ class PhoenixdHttpClient(PhoenixdClientBase):
     ):
         raise NotImplementedError()
 
-    async def incoming_payments_external_id(self, external_id: str):
-        raise NotImplementedError()
+    async def incoming_payments_external_id(
+        self, external_id: str
+    ) -> list[IncomingPaymentResponse]:
+        async with self.session.get(
+            self.baseurl / "payments" / "incoming",
+            params=[("externalId", external_id)],
+        ) as response:
+            return [
+                IncomingPaymentResponse.parse_obj(payment)
+                for payment in await response.json()
+            ]
 
-    async def incoming_payment_hash(self, hash: str | bytes):
-        raise NotImplementedError()
+    async def incoming_payment_hash(self, payment_hash: str) -> IncomingPaymentResponse:
+        async with self.session.get(
+            self.baseurl / "payments" / "incoming" / payment_hash,
+        ) as response:
+            return IncomingPaymentResponse.parse_obj(await response.json())
 
     async def outgoing_payment_id(self, payment_id: str):
         raise NotImplementedError()
@@ -222,10 +256,9 @@ class PhoenixdMockClient(PhoenixdClientBase):
         self,
         *,
         amount_sat: int,
-        description: str | bytes,
+        description: str,
         external_id: str | None = None,
     ) -> CreateInvoiceResponse:
-        # Static mock invoice
         invoice = CreateInvoiceResponse.parse_obj(
             {
                 "amountSat": amount_sat,
@@ -271,11 +304,48 @@ class PhoenixdMockClient(PhoenixdClientBase):
     ):
         raise NotImplementedError()
 
-    async def incoming_payments_external_id(self, external_id: str):
+    async def incoming_payments_external_id(
+        self, external_id: str
+    ) -> list[IncomingPaymentResponse]:
         raise NotImplementedError()
 
-    async def incoming_payment_hash(self, hash: str | bytes):
-        raise NotImplementedError()
+    async def incoming_payment_hash(self, payment_hash: str) -> IncomingPaymentResponse:
+        return IncomingPaymentResponse.parse_obj(
+            {
+                "paymentHash": payment_hash,
+                "preimage": "ee42430339e9d9c88b8b25f6d82eced562af242f0c24cbd728582992b804d168",
+                "externalId": "zap-49c9dccc-12b5-486d-ad00-4bf76eaf8c5f",
+                "description": (
+                    '{"kind":9734,"id":"c66329d84a2acf1c11296b3efc42931dd00d76'
+                    'b8bfb8e5b37d43bff8fa921914","sig":"6e620802ec934fdc7580df'
+                    "54a852161e9732414d0963c10de9f42b831065cf139b8e9f8aa333b42"
+                    '81376d4c42b281d48e5ece4643f8a42091a4788da3a1fe116","pubke'
+                    'y":"e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15'
+                    'e67149886cf","created_at":1713722971,"tags":[["p","e8b4b3'
+                    "0e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886c"
+                    'f"],["amount","1337000"],["relays","wss://relay.nostr.ban'
+                    'd/","wss://nos.lol/","wss://relay.damus.io/"],["e","4af81'
+                    "8a397daa226a85e8012197bee9ac4fd9cce85b4949334481d0c5bc573"
+                    '22"]],"content":""}'
+                ),
+                "invoice": (
+                    "lntb1u1pnquurmpp5xr83mlrg4d79e5w8nsrq6fksq83kreptr8uvcyy3"
+                    "0r2fsve9n6fqcqpjsp5ut3l5lvwpwyjcqf508nzdtze65zl2yycm45uee"
+                    "elktu3phzv2fsq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdrytddjyar"
+                    "90p69ctmsd3skjm3z9s395ctsypekzar0wd5xjgja93djyar90p69ctmf"
+                    "v3jkuarfve5k2u3z9s38xct5daeks6fzt4wsmqz9grzjqwfn3p9278ttz"
+                    "zpe0e00uhyxhned3j5d9acqak5emwfpflp8z2cnflcdkeu6euv7gsqqqq"
+                    "lgqqqqqeqqjqvyrulmkm8x58s9vahdm3z7jlj00pgl04xhfd0gjlm0e5e"
+                    "z7llfg49ra6pl96808deh95ysvmxajhfse4033k2deh58mrgdjj8kz8s6"
+                    "gpd82r8j"
+                ),
+                "isPaid": True,
+                "receivedSat": 10,
+                "fees": 0,
+                "completedAt": 1713300291913,
+                "createdAt": 1713300266711,
+            }
+        )
 
     async def outgoing_payment_id(self, payment_id: str):
         raise NotImplementedError()

--- a/app/phoenixd_client_test.py
+++ b/app/phoenixd_client_test.py
@@ -1,3 +1,5 @@
+from hashlib import sha256
+
 import pytest
 
 from .phoenixd_client import (
@@ -36,3 +38,75 @@ async def test_mock_client_createinvoice():
         )
         == inv
     )
+
+
+@pytest.mark.asyncio
+async def test_mock_client_createinvoice_description_hash():
+    settings = PhoenixdLNURLSettings(_env_file="test.env")
+    client = PhoenixdMockClient(phoenixd_url=settings.phoenixd_url.get_secret_value())
+    inv = await client.createinvoice(
+        amount_sat=1337,
+        description=None,
+        description_hash=sha256(b"test").hexdigest(),
+        external_id="test_inv",
+    )
+    assert (
+        CreateInvoiceResponse(
+            amountSat=1337,
+            paymentHash=(
+                "30cf1dfc68ab7c5cd1c79c060d26d001e361e42b19f8cc109178d49833259e92"
+            ),
+            serialized=(
+                "lntb1u1pnquurmpp5xr83mlrg4d79e5w8nsrq6fksq83kreptr8uvcyy3"
+                "0r2fsve9n6fqcqpjsp5ut3l5lvwpwyjcqf508nzdtze65zl2yycm45uee"
+                "elktu3phzv2fsq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdrytddjyar"
+                "90p69ctmsd3skjm3z9s395ctsypekzar0wd5xjgja93djyar90p69ctmf"
+                "v3jkuarfve5k2u3z9s38xct5daeks6fzt4wsmqz9grzjqwfn3p9278ttz"
+                "zpe0e00uhyxhned3j5d9acqak5emwfpflp8z2cnflcdkeu6euv7gsqqqq"
+                "lgqqqqqeqqjqvyrulmkm8x58s9vahdm3z7jlj00pgl04xhfd0gjlm0e5e"
+                "z7llfg49ra6pl96808deh95ysvmxajhfse4033k2deh58mrgdjj8kz8s6"
+                "gpd82r8j"
+            ),
+        )
+        == inv
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_client_createinvoice_too_long_description():
+    settings = PhoenixdLNURLSettings(_env_file="test.env")
+    client = PhoenixdMockClient(phoenixd_url=settings.phoenixd_url.get_secret_value())
+    with pytest.raises(ValueError):
+        _ = await client.createinvoice(
+            amount_sat=1337,
+            description="x" * 129,
+            external_id="test_inv",
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_client_createinvoice_not_description_hash():
+    settings = PhoenixdLNURLSettings(_env_file="test.env")
+    client = PhoenixdMockClient(phoenixd_url=settings.phoenixd_url.get_secret_value())
+    with pytest.raises(ValueError) as exc_info:
+        _ = await client.createinvoice(
+            amount_sat=1337,
+            description=None,
+            description_hash="not a sha256 hexdigest",
+            external_id="test_inv",
+        )
+    assert exc_info.match("must be SHA256 hexdigest")
+
+
+@pytest.mark.asyncio
+async def test_mock_client_createinvoice_too_long_description_hash():
+    settings = PhoenixdLNURLSettings(_env_file="test.env")
+    client = PhoenixdMockClient(phoenixd_url=settings.phoenixd_url.get_secret_value())
+    with pytest.raises(ValueError) as exc_info:
+        _ = await client.createinvoice(
+            amount_sat=1337,
+            description=None,
+            description_hash="hello081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            external_id="test_inv",
+        )
+    assert exc_info.match("must be a valid SHA256 hexdigest")

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 
+import bech32
 import lnurl
 import qrcode.image.svg
 from pydantic import (
@@ -8,8 +9,15 @@ from pydantic import (
     Field,
     HttpUrl,
     SecretStr,
+    validator,
 )
 from qrcode.main import QRCode
+
+# NOTE no type hints available for secp256k1
+from secp256k1 import (  # type: ignore
+    PrivateKey,
+    PublicKey,
+)
 from yarl import URL
 
 MAX_CORN = 21_000_000 * 100_000_000
@@ -23,7 +31,9 @@ class PhoenixdLNURLSettings(BaseSettings):
     min_sats_receivable: int = Field(default=1, ge=1)
     max_sats_receivable: int = Field(default=MAX_CORN, ge=1)
     user_profile_image_url: HttpUrl | None = None
-    user_nostr_address: str | None = None
+    user_nostr_address: str | None = None  # npub
+    user_nostr_private_key: SecretStr | None = None  # nsec
+    nostr_relays: list[str] | None = None
     log_level: str = "INFO"
 
     # Enable development/debug features. Unsafe on prod.
@@ -34,6 +44,70 @@ class PhoenixdLNURLSettings(BaseSettings):
     # TODO use @computed_field when upgrading to Pydantic 2.x
     # https://docs.pydantic.dev/2.6/api/fields/#pydantic.fields.computed_field
     # So we can also use @functools.cached_property
+
+    @validator("user_nostr_private_key", always=True)
+    def check_nsec_matches_npub(cls, value, values):
+        if value is None:
+            return None
+        if (npub := values.get("user_nostr_address")) is None:
+            raise ValueError(
+                "Must have USER_NOSTR_ADDRESS if providing USER_NOSTR_PRIVATE_KEY"
+            )
+
+        pubkey_hex = (
+            PublicKey(pubkey=bytes.fromhex("02" + npub_to_hex(npub)), raw=True)
+            .serialize()
+            .hex()
+        )
+
+        hrp, data = bech32.bech32_decode(value.get_secret_value())
+        if hrp != "nsec":
+            raise ValueError("USER_NOSTR_PRIVATE_KEY must be an 'nsec'")
+        if data is None:
+            raise ValueError("Couldn't decode USER_NOSTR_PRIVATE_KEY (expected nsec)")
+
+        maybe_raw_private_key = bech32.convertbits(data, 5, 8)
+        del data
+        if maybe_raw_private_key is None:
+            raise ValueError("Couldn't decode USER_NOSTR_PRIVATE_KEY (expected nsec)")
+        raw_private_key = bytes(maybe_raw_private_key[:-1])
+        del maybe_raw_private_key
+        privkey = PrivateKey(privkey=raw_private_key, raw=True)
+        del raw_private_key
+        derived_pubkey_hex = privkey.pubkey.serialize().hex()
+        del privkey
+
+        if derived_pubkey_hex != pubkey_hex:
+            raise ValueError(
+                "Public key for provided USER_NOSTR_PRIVATE_KEY does not match USER_NOSTR_ADDRESS"
+            )
+
+        return value
+
+    def nostr_private_key(self) -> PrivateKey:
+        if self.user_nostr_private_key is None:
+            raise ValueError("USER_NOSTR_PRIVATE_KEY is not set")
+        hrp, data = bech32.bech32_decode(self.user_nostr_private_key.get_secret_value())
+        if hrp != "nsec":
+            raise ValueError("USER_NOSTR_PRIVATE_KEY must be an 'nsec'")
+        if data is None:
+            raise ValueError("Couldn't decode USER_NOSTR_PRIVATE_KEY (expected nsec)")
+        maybe_raw_private_key = bech32.convertbits(data, 5, 8)
+        del data
+        if maybe_raw_private_key is None:
+            raise ValueError("Couldn't decode USER_NOSTR_PRIVATE_KEY (expected nsec)")
+        raw_private_key = bytes(maybe_raw_private_key[:-1])
+        del maybe_raw_private_key
+        privkey = PrivateKey(privkey=raw_private_key, raw=True)
+        del raw_private_key
+        return privkey
+
+    def supports_nostr_zaps(self) -> bool:
+        # Private key (nsec) is required for Zaps so we can create Zap Receipts (NIP-57)
+        return (
+            self.user_nostr_private_key is not None
+            and self.user_nostr_address is not None
+        )
 
     def base_url(self) -> URL:
         # TODO support `http` for `.onion` only (per LNURL spec)
@@ -50,7 +124,8 @@ class PhoenixdLNURLSettings(BaseSettings):
 
     def lnurl_qr(self) -> str:
         lnurl_qr = QRCode(
-            image_factory=qrcode.image.svg.SvgPathFillImage,
+            # NOTE mypy unhappy with passing this class but seems correct
+            image_factory=qrcode.image.svg.SvgPathFillImage,  # type: ignore
             box_size=15,
         )
         lnurl_qr.add_data(self.lnurl_address_encoded())
@@ -62,7 +137,6 @@ class PhoenixdLNURLSettings(BaseSettings):
             [
                 ["text/plain", f"Zap {self.username} some sats"],
                 ["text/identifier", self.lnurl_address()],
-                # ["image/jpeg;base64", "TODO optional"],
             ]
         )
 
@@ -71,6 +145,24 @@ class PhoenixdLNURLSettings(BaseSettings):
             self.metadata_for_payrequest().encode("UTF-8")
         ).hexdigest()
 
+    def user_nostr_address_hex(self) -> str | None:
+        if not self.user_nostr_address:
+            return None
+        return npub_to_hex(self.user_nostr_address)
+
     class Config:
         env_file = "phoenixd-lnurl.env"
         env_file_encoding = "utf-8"
+
+
+def npub_to_hex(npub: str) -> str | None:
+    hrp, data = bech32.bech32_decode(npub)
+    if hrp != "npub":
+        return None
+    if data is None:
+        return None
+    maybe_raw_public_key = bech32.convertbits(data, 5, 8)
+    if maybe_raw_public_key is None:
+        return None
+    raw_public_key = maybe_raw_public_key[:-1]
+    return bytes(raw_public_key).hex()

--- a/app/settings_test.py
+++ b/app/settings_test.py
@@ -7,14 +7,15 @@ from .settings import PhoenixdLNURLSettings
 def test_testenv_settings_load():
     settings = PhoenixdLNURLSettings(_env_file="test.env")
     assert settings.is_test is True
-    assert settings.debug is True
+    assert settings.debug is False
     assert settings.username == "satoshi"
     assert settings.lnurl_hostname == "127.0.0.1"
     assert settings.phoenixd_url == SecretStr("http://satoshi:hunter2@127.0.0.1:9740")
     assert (
         settings.user_nostr_address
-        == "npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f"
+        == "npub1az6txrn8e84tcuvsrpp4u4awgh7samp0dtdy9zcy690xw9ycsm8suq2sze"
     )
+    assert settings.nostr_relays == ["wss://nostr.bitcoin.org"]
     assert settings.user_profile_image_url == "https://bitcoin.org/satoshi.png"
     assert settings.log_level == "DEBUG"
     assert settings.min_sats_receivable == 1000
@@ -30,6 +31,7 @@ def test_default_settings_load():
     assert settings.lnurl_hostname == "example.com"
     assert settings.phoenixd_url == SecretStr("http://_:hunter2@127.0.0.1:9740")
     assert settings.user_nostr_address is None
+    assert settings.nostr_relays is None
     assert settings.user_profile_image_url is None
     assert settings.log_level == "INFO"
     assert settings.min_sats_receivable == 1
@@ -53,8 +55,24 @@ def test_testenv_settings_derived_properties():
         settings.metadata_hash()
         == "297f16bedbf6942cdc656e19feb46a577a43a87e1f858fd8511ac7144b84f0de"
     )
+    assert settings.supports_nostr_zaps() is True
+    assert (
+        settings.user_nostr_address_hex()
+        == "e8b4b30e67c9eabc719018435e57ae45fd0eec2f6ada428b04d15e67149886cf"
+    )
 
     assert settings.is_long_username() is False
 
     settings.username = "marttimalmi"
     assert settings.is_long_username() is True
+
+
+def test_settings_derived_properties_no_nostr():
+    settings = PhoenixdLNURLSettings(
+        _env_file=None,
+        username="satoshi",
+        lnurl_hostname="127.0.0.1",
+        phoenixd_url="http://satoshi:hunter2@127.0.0.1:9740",
+    )
+    assert settings.supports_nostr_zaps() is False
+    assert settings.user_nostr_address_hex() is None

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     labels:
       # CHANGEME set `Host(...)` to match your domain, or to `localhost` for testing:
       - "traefik.enable=true"
-      - "traefik.http.routers.phoenixd-lnurl.rule=Host(`example.com`) && Path(`/lnurl`) || Host(`example.com`) && PathPrefix(`/lnurlp`) || Host(`example.com`) && PathPrefix(`/.well-known/lnurlp`)"
+      - "traefik.http.routers.phoenixd-lnurl.rule=Host(`example.com`) && Path(`/lnurl`) || Host(`example.com`) && PathPrefix(`/lnurlp`) || Host(`example.com`) && PathPrefix(`/.well-known/lnurlp`) && PathPrefix(`/.well-known/nostr.json`)"
       - "traefik.http.services.phoenixd-lnurl.loadbalancer.server.port=8000"
       - "traefik.http.routers.phoenixd-lnurl.entrypoints=websecure"
       - "traefik.http.routers.phoenixd-lnurl.tls.certresolver=selfhostedservices"

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    # Include this snipped in your nginx config
+    # Include this snippet in your nginx config
     # ...
 
     # phoenixd-lnurl
@@ -25,6 +25,17 @@ server {
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
     }
+    # Optional NIP-5 support
+    .well-known/nostr.json {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+    # NOTE don't add /phoenixd-webhook unless your phoenixd needs
+    # to go through this nginx proxy to reach phoenixd-lnurl an
+    # you're aware of the risks of doing that
 
     # ...
 }

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ lint:
 
 # Run python tests
 pytest *pytest_args="-vx":
-    IS_TEST=1 pytest {{pytest_args}}
+    IS_TEST=1 pytest --cov=app --cov-report html {{pytest_args}}
 
 # Run python type checking
 mypy *files=".":

--- a/phoenixd-lnurl.env.example
+++ b/phoenixd-lnurl.env.example
@@ -20,8 +20,13 @@ PHOENIXD_URL=http://_:hunter2@127.0.0.1:9740
 ## Optional; set to show a profile photo on your tips page `/lnurl`
 # USER_PROFILE_IMAGE_URL=https://example.com/your_profile_photo.png
 
-## Optional; set to show an `npub` or `nprofile` or NIP5 identifier on your tips page `/lnurl`
+## Optional; set an `npub` Nostr address to show on your tips page `/lnurl`
 # USER_NOSTR_ADDRESS=npub1...
+## Optional; if using the NIP-5 feature, which relays your above USER_NOSTR_ADDRESS posts to
+# NOSTR_RELAYS=["wss://nostr.example.com", "wss://..."]
+## Optional; if you want to recieve Nostr Zaps in addition to normal LNURL payments, we need a Nost private key
+## NOTE this can be provided as an environment variable instead, which may be safer
+# USER_NOSTR_PRIVATE_KEY=nsec1...
 
 ## Optional & Technical: Change the log level. Values: "INFO" (default), "DEBUG", "WARNING", etc.
 # LOG_LEVEL=DEBUG

--- a/phoenixd-lnurl.env.example
+++ b/phoenixd-lnurl.env.example
@@ -20,16 +20,22 @@ PHOENIXD_URL=http://_:hunter2@127.0.0.1:9740
 ## Optional; set to show a profile photo on your tips page `/lnurl`
 # USER_PROFILE_IMAGE_URL=https://example.com/your_profile_photo.png
 
+##################
+## NOSTR SUPPORT
+##################
+
 ## Optional; set an `npub` Nostr address to show on your tips page `/lnurl`
 # USER_NOSTR_ADDRESS=npub1...
 ## Optional; if using the NIP-5 feature, which relays your above USER_NOSTR_ADDRESS posts to
 # NOSTR_RELAYS=["wss://nostr.example.com", "wss://..."]
+
+#####################
+## NOSTR ZAP SUPPORT
+#####################
+
 ## Optional; if you want to recieve Nostr Zaps in addition to normal LNURL payments, we need a Nost private key
 ## NOTE this can be provided as an environment variable instead, which may be safer
 # USER_NOSTR_PRIVATE_KEY=nsec1...
 
 ## Optional & Technical: Change the log level. Values: "INFO" (default), "DEBUG", "WARNING", etc.
 # LOG_LEVEL=DEBUG
-
-## WARNING: Intended for development only, enables useful but dangerous-in-public debug features
-# DEBUG=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,14 @@ select = [
     "I",
 ]
 ignore = [
-    # line-too-long
+    # "line-too-long"
     # We're using `ruff` to format the code, so iff the formatter
     # can't get the line length low enough we'll assume it reads better
     # as a long line rather than broken up
     "E501",
+    # "Use a single if statement"
+    # Doesn't recognise walrus operator assignment
+    "SIM102",
 ]
 fixable = ["ALL"]
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,5 +6,6 @@ ipython
 mypy
 pytest
 pytest-asyncio
+pytest-cov
 ruff
 types-qrcode

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,6 +46,8 @@ click==8.1.7
     # via
     #   -c requirements.txt
     #   uvicorn
+coverage==7.4.4
+    # via pytest-cov
 decorator==5.1.1
     # via ipython
 dnspython==2.6.1
@@ -180,7 +182,10 @@ pytest==8.1.1
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio
+    #   pytest-cov
 pytest-asyncio==0.23.6
+    # via -r requirements-dev.in
+pytest-cov==5.0.0
     # via -r requirements-dev.in
 python-dotenv==1.0.1
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --strip-extras requirements-dev.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   -c requirements.txt
     #   -r requirements.in
@@ -34,6 +34,10 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
+cffi==1.16.0
+    # via
+    #   -c requirements.txt
+    #   secp256k1
 charset-normalizer==3.3.2
     # via
     #   -c requirements.txt
@@ -85,7 +89,7 @@ httpx==0.27.0
     #   -c requirements.txt
     #   -r requirements-dev.in
     #   fastapi
-idna==3.6
+idna==3.7
     # via
     #   -c requirements.txt
     #   anyio
@@ -120,7 +124,7 @@ markupsafe==2.1.5
     # via
     #   -c requirements.txt
     #   jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
 multidict==6.0.5
     # via
@@ -140,7 +144,7 @@ packaging==24.0
     #   -c requirements.txt
     #   gunicorn
     #   pytest
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
@@ -156,6 +160,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
+pycparser==2.22
+    # via
+    #   -c requirements.txt
+    #   cffi
 pydantic==1.10.14
     # via
     #   -c requirements.txt
@@ -196,8 +204,12 @@ requests==2.31.0
     # via
     #   -c requirements.txt
     #   lnurl
-ruff==0.3.5
+ruff==0.3.7
     # via -r requirements-dev.in
+secp256k1==0.14.0
+    # via
+    #   -c requirements.txt
+    #   -r requirements.in
 six==1.16.0
     # via asttokens
 sniffio==1.3.1
@@ -215,9 +227,9 @@ traitlets==5.14.2
     # via
     #   ipython
     #   matplotlib-inline
-types-qrcode==7.4.0.20240106
+types-qrcode==7.4.0.20240408
     # via -r requirements-dev.in
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   -c requirements.txt
     #   fastapi

--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,6 @@ lnurl
 loguru
 pydantic[dotenv]==1.10.14  # NOTE stuck on <2.0.0 because of lnurl compat issue
 qrcode[pil]
+secp256k1
 uvicorn[standard]
 yarl

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --strip-extras
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
@@ -22,6 +22,8 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
+cffi==1.16.0
+    # via secp256k1
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -48,7 +50,7 @@ httptools==0.6.1
     # via uvicorn
 httpx==0.27.0
     # via fastapi
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   email-validator
@@ -77,6 +79,8 @@ packaging==24.0
     # via gunicorn
 pillow==10.3.0
     # via qrcode
+pycparser==2.22
+    # via cffi
 pydantic==1.10.14
     # via
     #   -r requirements.in
@@ -98,13 +102,15 @@ qrcode==7.4.2
     # via -r requirements.in
 requests==2.31.0
     # via lnurl
+secp256k1==0.14.0
+    # via -r requirements.in
 sniffio==1.3.1
     # via
     #   anyio
     #   httpx
 starlette==0.27.0
     # via fastapi
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   fastapi
     #   pydantic

--- a/test.env
+++ b/test.env
@@ -1,12 +1,14 @@
 # NOTE: This .env file is used when running python tests, see
 # `phoenixd-lnurl.env.example` instead for a template to copy.
 IS_TEST=1
-DEBUG=1
+DEBUG=0
 USERNAME=satoshi
 LNURL_HOSTNAME='127.0.0.1'
 PHOENIXD_URL='http://satoshi:hunter2@127.0.0.1:9740'
 MIN_SATS_RECEIVABLE=1000
 MAX_SATS_RECEIVABLE=500000
 USER_PROFILE_IMAGE_URL='https://bitcoin.org/satoshi.png'
-USER_NOSTR_ADDRESS='npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f'
+USER_NOSTR_ADDRESS=npub1az6txrn8e84tcuvsrpp4u4awgh7samp0dtdy9zcy690xw9ycsm8suq2sze
+USER_NOSTR_PRIVATE_KEY=nsec1vcdx9xcq29lxc40htmh26dv4zz47rukqfcr9xx46lvlxvm7247hs4u4k4v
+NOSTR_RELAYS=["wss://nostr.bitcoin.org"]
 LOG_LEVEL='DEBUG'

--- a/test.env
+++ b/test.env
@@ -1,7 +1,11 @@
 # NOTE: This .env file is used when running python tests, see
 # `phoenixd-lnurl.env.example` instead for a template to copy.
+
+## WARNING: Intended for development only, enables useful but dangerous-in-public debug features 
 IS_TEST=1
 DEBUG=0
+
+## Other settings:
 USERNAME=satoshi
 LNURL_HOSTNAME='127.0.0.1'
 PHOENIXD_URL='http://satoshi:hunter2@127.0.0.1:9740'


### PR DESCRIPTION
 - Adds Phoenixd webhook endpoint `/phoenixd-webhook` (needs phoenixd config `webhook=http://localhost:8000/phoenixd-webhook`)
 - Create Nostr Zap Receipt events (requires new config `USER_NOSTR_PRIVATE_KEY=nsec1...`)
 - Publish Zap Receipt events to relays specified in the Zap Request event in a background task
 - Add tests for new Nostr behaviour
 - Nostr support for Docker, docker-compose. README update for new config and details.

- [x] Don't smuggle Nostr Zap request event in the invoice description as they are often longer than the BOLT-11 maximum allowable size of 639 bytes.
    - Resolved by https://github.com/ACINQ/phoenixd/pull/50 and `phoenixd 0.1.5` release
- [ ] But now that means we have to persist the zaps ourselves rather than lazily rely on phoenixd to remember them for us in invoice descriptions